### PR TITLE
Rename pytest marker from integration_tests to integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ endef
 # Integration testing functions
 define test-common-integrations
 	echo "\n=== Running integration tests for $(2) ==="
-	(cd $(1) && uv run pytest -s -m integration_tests -vvv -W "error::Warning" -W "default::PendingDeprecationWarning" $(2))
+	(cd $(1) && uv run pytest -s -m integration -vvv -W "error::Warning" -W "default::PendingDeprecationWarning" $(2))
 	echo "=== Integration tests completed successfully for $(2) ==="
 endef
 

--- a/design/002-python-3-14-support-drop-3-10.md
+++ b/design/002-python-3-14-support-drop-3-10.md
@@ -323,7 +323,7 @@ requires-python = ">=3.11,<3.15"
   - Update or add tests in `mountaineer/__tests__/actions/` to ensure sideeffect/passthrough payloads serialize with the
     TypedDict-based payload model (no 3.10 fallback paths).
 - **Integration tests**
-  - Run existing integration tests (`@pytest.mark.integration_tests`) across Python 3.11-3.14 in CI to validate end-to-end
+  - Run existing integration tests (`@pytest.mark.integration`) across Python 3.11-3.14 in CI to validate end-to-end
     behavior.
   - Execute `make test-lib-integrations` in CI matrix to ensure the fixture webapp aligns with new requirements.
 - **Version matrix coverage**

--- a/design/002-python-3-14-support-drop-3-10.md
+++ b/design/002-python-3-14-support-drop-3-10.md
@@ -371,7 +371,7 @@ requires-python = ">=3.11,<3.15"
 
 - [ ] **Testing and validation**
   - [ ] Run `uv run pytest` (unit tests)
-  - [ ] Run `uv run pytest -m integration_tests`
+  - [ ] Run `uv run pytest -m integration`
   - [ ] Run lint and type checks (`uv run ruff check`, `uv run mypy`, `uv run pyright`)
   - [ ] Verify CI matrix green for 3.11-3.14
 

--- a/mountaineer/__tests__/test_cli.py
+++ b/mountaineer/__tests__/test_cli.py
@@ -72,7 +72,7 @@ async def check_server_bound(port: int, timeout=8):
     return False, -1
 
 
-@pytest.mark.integration_tests
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_handle_runserver_with_user_modifications(tmp_ci_webapp: Path):
     # Ensure that there is no existing webapp running

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,9 +77,9 @@ select = ["E4", "E7", "E9", "F", "I001", "T201"]
 combine-as-imports = true
 
 [tool.pytest.ini_options]
-markers = ["integration_tests: run longer-running integration tests"]
+markers = ["integration: run longer-running integration tests"]
 # Default pytest runs shouldn't execute the integration tests
-addopts = "-m 'not integration_tests'"
+addopts = "-m 'not integration'"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- Renamed the pytest marker from `integration_tests` to `integration` for consistency and brevity
- Updated marker definition and configuration in `pyproject.toml`
- Updated test decorator in `mountaineer/__tests__/test_cli.py`
- Updated documentation reference in design document

## Test plan
- [ ] Verify unit tests still run by default: `pytest`
- [ ] Verify integration tests are skipped by default
- [ ] Verify integration tests can be run explicitly: `pytest -m integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)