### PR TITLE
docs: format mdx content

### DIFF
--- a/.codex/skills/commit-and-push/SKILL.md
+++ b/.codex/skills/commit-and-push/SKILL.md
@@ -31,8 +31,8 @@ Use this workflow to validate changes, fix failures, create a conventional commi
   - If hooks conflict (format vs. lint), resolve the underlying formatting/code issue, then re-run the affected hooks.
 - When all hooks pass, run `uv run pre-commit run --all` again to confirm.
 - Ruff is the linter; rules are in `pyproject.toml`.
-- Type checking uses `ty`. Use specific ignores only when needed, e.g. `# ty: ignore[attr-defined]` with a short reason
-  when not obvious.
+- Type checking uses `ty`.
+  Use specific ignores only when needed, e.g. `# ty: ignore[attr-defined]` with a short reason when not obvious.
 - Pre-commit configuration is in `.pre-commit-config.yaml`.
 
 ### 3) Commit

--- a/.codex/skills/design-doc/SKILL.md
+++ b/.codex/skills/design-doc/SKILL.md
@@ -7,12 +7,14 @@ description: Create a detailed design document in a repo's design/ folder using 
 
 ## Goal
 
-Turn a user prompt into a **highly detailed design document** saved under `design/NNN-kebab-title.md`, following the
-repo’s template and conventions. This skill is design-only (no implementation) and does not perform external research.
+Turn a user prompt into a **highly detailed design document**.
+Save it under `design/NNN-kebab-title.md`, following the repo's template and conventions.
+This skill is design-only (no implementation) and does not perform external research.
 
 ## Minimal workflow (step-by-step)
 
-Throughout the workflow, do not browse the web. Use only local repo files and user-provided resources.
+Throughout the workflow, do not browse the web.
+Use only local repo files and user-provided resources.
 
 1. **Scan context quickly**
    - Read `design/000-design-template.md` and `design/000-design-example.md`.
@@ -132,7 +134,8 @@ Use the repo’s template if it differs; otherwise follow this skeleton exactly.
 
 Good:
 
-- **Overview**: Clear problem statement, why it matters, and how this design solves it. Goals are testable.
+- **Overview**: Clear problem statement, why it matters, and how this design solves it.
+  Goals are testable.
 - **Workflows**: Each workflow includes Description, Usage Example, Call Graph, Key Components, plus a Sequence Diagram
   when multi-component.
 - **Dependencies**: Mermaid graph clearly labels new vs existing modules.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,25 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+  - repo: local
+    hooks:
+      - id: uv-lock
+        name: uv lock
+        entry: uv lock
+        language: python
+        files: ^(uv\.lock|pyproject\.toml|uv\.toml)$
+        args: []
+        pass_filenames: false
+        additional_dependencies: []
+      - id: rumdl-fmt
+        name: rumdl fmt
+        entry: uv run rumdl fmt
+        language: python
+        types: [markdown]
+        require_serial: true
+      - id: rumdl-check
+        name: rumdl check
+        entry: uv run rumdl check
+        language: python
+        types: [markdown]
+        require_serial: true

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 ![Mountaineer Logo](https://raw.githubusercontent.com/piercefreeman/mountaineer/main/media/header.png)
 
-![Python Version](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fpiercefreeman%2Fmountaineer%2Frefs%2Fheads%2Fmain%2Fpyproject.toml)
-[![Test status](https://github.com/piercefreeman/mountaineer/actions/workflows/test.yml/badge.svg)](https://github.com/piercefreeman/mountaineer/actions)
+![Python Version](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fpiercefreeman%2Fmountaineer%2Frefs%2Fheads%2Fmain%2Fpyproject.toml) [![Test status](https://github.com/piercefreeman/mountaineer/actions/workflows/test.yml/badge.svg)](https://github.com/piercefreeman/mountaineer/actions)
 
+*Move fast, climb mountains, and don't break things.*
 
-<p align="center"><i>Move fast. Climb mountains. Don't break things.</i></p>
-
-Mountaineer 🏔️ is a framework to easily build webapps in Python and React. If you've used either of these languages before for development, we think you'll be right at home.
+Mountaineer 🏔️ is a framework to easily build webapps in Python and React.
+If you've used either of these languages before for development, we think you'll be right at home.
 
 ## Main Features
 
-Each framework has its own unique features and tradeoffs. Mountaineer focuses on developer productivity above all else, with production speed a close second.
+Each framework has its own unique features and tradeoffs.
+Mountaineer focuses on developer productivity above all else, with production speed a close second.
 
 - 📝 Typehints up and down the stack: frontend, backend, and database
 - 🎙️ Trivially easy client<->server communication, data binding, and function calling
@@ -24,11 +24,14 @@ Each framework has its own unique features and tradeoffs. Mountaineer focuses on
 
 ### New Project
 
-To get started with a new Mountaineer project, refer to our [quickstart guide](https://mountaineer.sh/mountaineer/guides/quickstart) which walks you through setting up a project from scratch.
+To get started with a new Mountaineer project, refer to our
+[quickstart guide](https://mountaineer.sh/mountaineer/guides/quickstart) which walks you through setting up a
+project from scratch.
 
-Mountaineer projects all follow a similar structure. After running this CLI you should see a new folder called `my_webapp`, with folders like the following:
+Mountaineer projects all follow a similar structure.
+After running this CLI you should see a new folder called `my_webapp`, with folders like the following:
 
-```
+```text
 my_webapp
   /controllers
     /home.py
@@ -46,7 +49,12 @@ my_webapp
 pyproject.toml
 ```
 
-Every service file is nested under the `my_webapp` root package. Views are defined in a disk-based hierarchy (`views`) where nested routes are in nested folders. This folder acts as your React project and is where you can define requirements and build parameters in `package.json` and `tsconfig.json`. Controllers are defined nearby in a flat folder (`controllers`) where each route is a separate file. Everything else is just standard Python code for you to modify as needed.
+Every service file is nested under the `my_webapp` root package.
+Views are defined in a disk-based hierarchy (`views`) where nested routes are in nested folders.
+This folder acts as your React project.
+Define requirements and build parameters in `package.json` and `tsconfig.json`.
+Controllers are defined nearby in a flat folder (`controllers`) where each route is a separate file.
+Everything else is just standard Python code for you to modify as needed.
 
 ### Development
 
@@ -56,9 +64,11 @@ If you're starting a new application from scratch, you can immediately start the
 uv run runserver
 ```
 
-Mountaineer relies on watching your project for changes and doing progressive compilation. We provide a few CLI commands to help with this.
+Mountaineer relies on watching your project for changes and doing progressive compilation.
+We provide a few CLI commands to help with this.
 
-While doing development work, you'll usually want to preview the frontend and automatically build dependent files. You can do this with:
+While doing development work, you'll usually want to preview the frontend and automatically build dependent files.
+You can do this with:
 
 ```bash
 $ uv run runserver
@@ -69,12 +79,13 @@ INFO:     Application startup complete.
 INFO:     Uvicorn running on http://127.0.0.1:5006 (Press CTRL+C to quit)
 ```
 
-Navigate to http://127.0.0.1:5006 to see your new webapp running.
+Navigate to <http://127.0.0.1:5006> to see your new webapp running.
 
-Or, if you just want to watch the source tree for changes without hosting the server. Watching will allow your frontend to pick up API definitions from your backend controllers:
+Or, if you just want to watch the source tree for changes without hosting the server.
+Watching will allow your frontend to pick up API definitions from your backend controllers:
 
 ```bash
-$ uv run watch
+uv run watch
 ```
 
 Both of these CLI commands are specified in your project's `cli.py` file.

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -1,4 +1,4 @@
-## benchmarking
+# benchmarking
 
 ```bash
 uv run locust -f benchmarking/simple_render.py -H http://127.0.0.1:5006

--- a/design/000-design-example.md
+++ b/design/000-design-example.md
@@ -4,9 +4,9 @@
 
 ### High-Level Description
 
-This feature adds a robust configuration validation system to the belgie project. It provides a declarative way to
-define configuration schemas and validate configuration dictionaries against those schemas. The validator will support
-type checking, value constraints, required fields, and custom validation rules.
+This feature adds a robust configuration validation system to the belgie project.
+It provides a declarative way to define configuration schemas and validate configuration dictionaries.
+The validator will support type checking, value constraints, required fields, and custom validation rules.
 
 The problem this solves: Currently, there's no centralized way to validate configuration inputs, leading to potential
 runtime errors when invalid configurations are passed to modules.
@@ -658,8 +658,9 @@ Tests should be organized by module/file and cover unit tests, integration tests
 - Learning curve for team members unfamiliar with Pydantic
 - May be overkill for this specific use case
 
-**Why not chosen**: The goal is to create a lightweight, project-specific validator that demonstrates architectural
-patterns and has no external dependencies. This is an educational exercise in building validation systems.
+**Why not chosen**: The goal is to create a lightweight validator.
+It should demonstrate architectural patterns with no dependencies.
+This is an educational exercise in building validation systems.
 
 ### Approach 2: Class-Based Validators
 
@@ -679,8 +680,9 @@ patterns and has no external dependencies. This is an educational exercise in bu
 - Less functional programming style
 - Slightly more complex API for simple validators
 
-**Why not chosen**: Closures provide a cleaner, more functional API for simple validators. The factory function pattern
-(`range_validator(1, 100)`) is more concise and readable than instantiating classes (`RangeValidator(min=1, max=100)`).
+**Why not chosen**: Closures provide a cleaner, more functional API for simple validators.
+The factory function pattern (`range_validator(1, 100)`) is more concise.
+It is shorter than instantiating classes (`RangeValidator(min=1, max=100)`).
 Since validators are stateless operations, functions are a better fit than classes.
 
 ### Approach 3: Decorator-Based Schema Definition
@@ -701,6 +703,5 @@ Since validators are stateless operations, functions are a better fit than class
 - Harder to reuse schemas across different classes
 - May not work well for validating plain dictionaries
 
-**Why not chosen**: The fluent API approach (`Schema().field(...)`) provides better separation of concerns and is more
-flexible for this use case. We're validating arbitrary configuration dictionaries, not necessarily tied to specific
-classes.
+**Why not chosen**: The fluent API approach (`Schema().field(...)`) provides better separation and is more flexible.
+We're validating arbitrary configuration dictionaries, not necessarily tied to specific classes.

--- a/design/001-fastapi-router-integration.md
+++ b/design/001-fastapi-router-integration.md
@@ -4,15 +4,16 @@
 
 ### High-Level Description
 
-Mountaineer currently owns the FastAPI application inside `AppController`, which forces users to reach through
-`controller.app` or maintain a separate `app = controller.app` file for ASGI deployment. This design replaces that
-pattern with a mountable `Mountaineer` ASGI application that can be attached to a user-owned FastAPI app via
-`app.mount(path="/", app=mountaineer, name="website")`. Mountaineer manages its internal FastAPI app, routes, static
-mounts, and OpenAPI customization internally, while the outer FastAPI app remains fully configurable by users.
+Mountaineer owns the FastAPI application inside `AppController`.
+This forces users to use `controller.app` or maintain a separate `app = controller.app` file for ASGI deployment.
+This design replaces that with a mountable `Mountaineer` ASGI application attached to a user-owned FastAPI app.
+It mounts via `app.mount(path="/", app=mountaineer, name="website")`.
+Mountaineer manages its internal FastAPI app, routes, and static mounts, while the outer app remains fully configurable.
 
-The mount prefix is resolved at runtime instead of configuration time. The server injects the active `root_path` into
-HTML responses, and the client-side runtime prefixes all generated action and link URLs using that value. This removes
-any need for a `mount_path` parameter while preserving correct URL generation under subpath mounts.
+The mount prefix is resolved at runtime instead of configuration time.
+The server injects the active `root_path` into HTML responses.
+The client runtime prefixes all generated action and link URLs.
+This removes any need for a `mount_path` parameter while preserving correct URL generation under subpath mounts.
 
 ### Goals
 
@@ -37,10 +38,10 @@ any need for a `mount_path` parameter while preserving correct URL generation un
 
 #### Description
 
-Users create their own `FastAPI` app, configure middleware/lifespan as needed, then mount a `Mountaineer` instance as
-an ASGI sub-application. Mountaineer uses its internal FastAPI app for all routing, exception handling, static mounts,
-and OpenAPI generation. The active mount prefix is injected into HTML responses and used by the client runtime to prefix
-requests and link generation.
+Users create their own `FastAPI` app and configure middleware/lifespan.
+Then they mount a `Mountaineer` instance as a sub-application.
+Mountaineer uses its internal FastAPI app for all routing, exception handling, static mounts, and OpenAPI generation.
+The active mount prefix is injected into HTML responses and used by the client runtime to prefix requests.
 
 #### Usage Example
 
@@ -262,7 +263,8 @@ Tests should be organized by module/file and cover unit tests, integration tests
 
 **Mountaineer sub-app tests:**
 
-- Mount at root: create `FastAPI()` and `Mountaineer(view_root=...)`, register a controller, then `app.mount("/", app=mountaineer)`
+- Mount at root: create `FastAPI()` and `Mountaineer(view_root=...)`, register a controller, then
+  `app.mount("/", app=mountaineer)`
 - Verify the view route is reachable via `TestClient(app)`
 - Verify action routes are reachable via `TestClient(app)`
 - Ensure `Mountaineer.__call__` delegates to the internal app

--- a/design/002-python-3-14-support-drop-3-10.md
+++ b/design/002-python-3-14-support-drop-3-10.md
@@ -4,10 +4,10 @@
 
 ### High-Level Description
 
-This change updates Mountaineer to officially support Python 3.14 while dropping Python 3.10. The work spans packaging
-metadata, CI/build matrices, lockfiles, and a small set of compatibility shims that only exist for 3.10-era behavior.
-The runtime surface area should remain stable, but we will simplify version-gated code paths to target Python 3.11-3.14
-only and align documentation and fixtures with the new supported range.
+This change updates Mountaineer to officially support Python 3.14 while dropping Python 3.10.
+The work spans packaging metadata, CI/build matrices, lockfiles, and compatibility shims for 3.10-era behavior.
+The runtime surface area should remain stable.
+We will simplify version-gated code paths to target Python 3.11-3.14 only and align docs with the new range.
 
 ### Goals
 
@@ -30,10 +30,9 @@ only and align documentation and fixtures with the new supported range.
 
 #### Description
 
-Sideeffect and passthrough actions construct response payloads that use TypedDict generics and NotRequired fields. With
-Python 3.10 dropped, we can rely on the built-in typing features in Python 3.11+ and remove the fallback TypedDict
-implementation. The decorators build the payload and hand it off to the response formatter without additional runtime
-branching for Python 3.10.
+Sideeffect and passthrough actions construct response payloads that use TypedDict generics and NotRequired fields.
+With Python 3.10 dropped, we can rely on built-in typing features in Python 3.11+ and remove fallback TypedDict.
+Decorators build the payload and hand it off to the response formatter without runtime branching for Python 3.10.
 
 #### Usage Example
 
@@ -82,7 +81,8 @@ sequenceDiagram
 
 #### Key Components
 
-- **SideeffectResponseBase** (`mountaineer/actions/fields.py:SideeffectResponseBase`) - TypedDict used for action payloads
+- **SideeffectResponseBase** (`mountaineer/actions/fields.py:SideeffectResponseBase`) - TypedDict used for
+  action payloads
 - **sideeffect decorator** (`mountaineer/actions/sideeffect_dec.py:sideeffect`) - Builds sideeffect payloads
 - **passthrough decorator** (`mountaineer/actions/passthrough_dec.py:passthrough`) - Builds passthrough payloads
 - **format_final_action_response** (`mountaineer/actions/fields.py`) - Serializes action responses
@@ -91,9 +91,10 @@ sequenceDiagram
 
 #### Description
 
-CI should test and lint against Python 3.11, 3.12, 3.13, and 3.14. Release builds should produce wheels for the same
-interpreter set and exclude 3.10. The rust-tests job should use the minimum supported version (3.11). Lockfiles in the
-root, .github, and benchmarking projects should be regenerated to reflect updated Python constraints.
+CI should test and lint against Python 3.11, 3.12, 3.13, and 3.14.
+Release builds should produce wheels for the same interpreter set and exclude 3.10.
+The rust-tests job should use the minimum supported version (3.11).
+Lockfiles in the root, .github, and benchmarking projects should be regenerated to reflect updated Python constraints.
 
 #### Usage Example
 
@@ -320,11 +321,11 @@ requires-python = ">=3.11,<3.15"
 
 - **Unit tests**
   - Re-run `mountaineer/__tests__/test_compat.py` to validate StrEnum behavior under Python 3.11-3.14.
-  - Update or add tests in `mountaineer/__tests__/actions/` to ensure sideeffect/passthrough payloads serialize with the
-    TypedDict-based payload model (no 3.10 fallback paths).
+  - Update or add tests in `mountaineer/__tests__/actions/` to ensure sideeffect/passthrough payloads serialize
+    with the TypedDict-based payload model (no 3.10 fallback paths).
 - **Integration tests**
-  - Run existing integration tests (`@pytest.mark.integration_tests`) across Python 3.11-3.14 in CI to validate end-to-end
-    behavior.
+  - Run existing integration tests (`@pytest.mark.integration_tests`) across Python 3.11-3.14 in CI to validate
+    end-to-end behavior.
   - Execute `make test-lib-integrations` in CI matrix to ensure the fixture webapp aligns with new requirements.
 - **Version matrix coverage**
   - Ensure CI `test`, `lint`, and `lib-integration-test` jobs cover 3.11-3.14.
@@ -337,9 +338,9 @@ requires-python = ">=3.11,<3.15"
 1. **Metadata and docs updates** (version range)
    - `pyproject.toml`, `.github/pyproject.toml`, `benchmarking/pyproject.toml`, docs, fixtures
 2. **Compatibility layer updates** (runtime typing)
-   - `mountaineer/compat.py`, `mountaineer/actions/fields.py`, `mountaineer/actions/sideeffect_dec.py`, `mountaineer/actions/passthrough_dec.py`
-3. **CI/build matrix updates**
-   - `.github/workflows/test.yml` and any related scripts
+   - `mountaineer/compat.py`, `mountaineer/actions/fields.py`, `mountaineer/actions/sideeffect_dec.py`,
+     `mountaineer/actions/passthrough_dec.py`
+3. **CI/build matrix updates** - `.github/workflows/test.yml` and any related scripts
 4. **Lockfile refresh**
    - `uv.lock`, `.github/uv.lock`, `benchmarking/uv.lock`
 5. **Test updates and validation**
@@ -377,9 +378,10 @@ requires-python = ">=3.11,<3.15"
 
 ## Open Questions
 
-1. Should we set an explicit upper bound in the root `requires-python` (e.g., `<3.15`) until 3.14 support is validated?
-2. Do we want to keep `typing_extensions` as a direct dependency (for `dataclass_transform`) or migrate to stdlib typing
-   now that 3.11 is the minimum?
+1. Should we set an explicit upper bound in the root `requires-python` (e.g., `<3.15`) until 3.14 support is
+   validated?
+2. Do we want to keep `typing_extensions` as a direct dependency (for `dataclass_transform`) or migrate to stdlib
+   typing now that 3.11 is the minimum?
 
 ## Future Enhancements
 
@@ -420,8 +422,8 @@ None.
 - More branching in runtime type hints and decorators
 - CI/build times increase with a larger version matrix
 
-**Why not chosen**: The goal is to reduce maintenance and align with modern Python features. Dropping 3.10 enables
-simpler typing constructs and fewer compatibility shims while still supporting 3.11+.
+**Why not chosen**: The goal is to reduce maintenance and align with modern Python features.
+Dropping 3.10 enables simpler typing constructs and fewer compatibility shims while still supporting 3.11+.
 
 ### Approach 2: Drop 3.10 and 3.11, Target 3.12+ Only
 
@@ -437,8 +439,8 @@ simpler typing constructs and fewer compatibility shims while still supporting 3
 - Drops a larger segment of users
 - Increases migration burden for downstream projects
 
-**Why not chosen**: 3.11 is still widely used and offers most of the typing/runtime features needed here. Limiting to
-3.12+ is unnecessary for the scope of this change.
+**Why not chosen**: 3.11 is still widely used and offers most of the typing/runtime features needed here.
+Limiting to 3.12+ is unnecessary for the scope of this change.
 
 ### Approach 3: Treat 3.14 as Experimental Only
 

--- a/design/002-remove-plugins.md
+++ b/design/002-remove-plugins.md
@@ -4,17 +4,17 @@
 
 ### High-Level Description
 
-Mountaineer currently ships a plugin system (`MountaineerPlugin`) that allows external packages to register
-controllers with separate view roots and precompiled assets. This adds complexity across controller registration,
-static asset routing, build pipelines, and dev tooling (including a plugin-based exception page). The request is to
-remove plugin support entirely and delete infrastructure that only exists to support plugins, including
-`IsolatedAppContext`.
+Mountaineer ships a plugin system (`MountaineerPlugin`).
+It lets external packages register controllers with separate view roots.
+This adds complexity across controller registration, static routing, build pipelines, and dev tooling.
+This design removes plugin support entirely.
+It deletes infrastructure like `IsolatedAppContext` that only supports plugins.
 
-This design removes the `MountaineerPlugin` API and all plugin-only logic from the core, simplifying registration,
-build, and runtime assumptions to a single view root. It also replaces the isolated-process development pipeline
-with an in-process `DevSession` that manages app initialization and build steps without external plugins. The CLI
-(`handle_runserver`, `handle_watch`, `handle_build`) will call this new session directly. Documentation and tests
-are updated to reflect the removal and the simplified workflow.
+This design removes the `MountaineerPlugin` API and plugin-only logic.
+It simplifies registration, build, and runtime to a single view root.
+It replaces the isolated-process pipeline with an in-process `DevSession` managing app initialization and builds.
+The CLI (`handle_runserver`, `handle_watch`, `handle_build`) will call this new session directly.
+Documentation and tests are updated to reflect the removal and the simplified workflow.
 
 ### Goals
 
@@ -38,9 +38,9 @@ are updated to reflect the removal and the simplified workflow.
 
 #### Description
 
-Users register `ControllerBase` / `LayoutControllerBase` instances directly on a `Mountaineer` instance. Plugin
-objects are no longer supported; static asset routing always uses the default `/static` prefix and the single
-project view root. Build steps and dev tooling operate exclusively on that root.
+Users register `ControllerBase` / `LayoutControllerBase` instances directly on a `Mountaineer` instance.
+Plugin objects are no longer supported; static routing uses the default `/static` prefix and single project view.
+Build steps and dev tooling operate exclusively on that root.
 
 #### Usage Example
 
@@ -100,10 +100,11 @@ sequenceDiagram
 
 #### Description
 
-The CLI creates a `DevSession` that loads the Mountaineer instance, initializes builders, runs a dev server, and
-watches files. JS/TS/CSS changes trigger frontend rebuilds. Python changes trigger module reload and reinitialization
-of the Mountaineer instance. The Watcher webservice broadcasts rebuild notifications. No custom dev exception page
-is installed.
+The CLI creates a `DevSession` that loads the Mountaineer instance, initializes builders, and runs a dev server.
+JS/TS/CSS changes trigger frontend rebuilds.
+Python changes trigger module reload and reinitialization of the Mountaineer instance.
+The Watcher webservice broadcasts rebuild notifications.
+No custom dev exception page is installed.
 
 #### Usage Example
 
@@ -374,7 +375,7 @@ class PostCSSBundler(APIBuilderBase):
 
 Tests should be organized by module/file and cover unit tests, integration tests, and edge cases.
 
-#### `mountaineer/__tests__/development/test_session.py`
+### `mountaineer/__tests__/development/test_session.py`
 
 - Create `DevSession` from a fixture webcontroller and validate `mountaineer`, `js_compiler`, `app_compiler` are set.
 - Verify `build_use_server()` delegates to `APIBuilder` (mocked).
@@ -399,7 +400,8 @@ Tests should be organized by module/file and cover unit tests, integration tests
 
 #### `mountaineer/__tests__/test_cli.py`
 
-- Patch `DevSession` in `handle_build` and assert expected sequence (`initialize_app_state`, `build_use_server`, `run_builder_plugins`).
+- Patch `DevSession` in `handle_build` and assert expected sequence (`initialize_app_state`, `build_use_server`,
+  `run_builder_plugins`).
 
 **Integration Tests:**
 

--- a/docs/api/actions/page.mdx
+++ b/docs/api/actions/page.mdx
@@ -1,9 +1,8 @@
 # Actions
 
-Render functions control the data that is pushed from the server to the client. Anything
-that is sent from a client to a server is considered an action. Actions are
-internally implemented as POST requests that are handled in Javascript, but once built
-on the frontend should be fully transparent to you.
+Render functions control the data that is pushed from the server to the client.
+Anything that is sent from a client to a server is considered an action.
+Actions are internally implemented as POST requests that are handled in Javascript, but once built on the frontend should be fully transparent to you.
 
 ---
 

--- a/docs/api/api_exception/page.mdx
+++ b/docs/api/api_exception/page.mdx
@@ -1,5 +1,7 @@
 # API Exception
 
-The `APIException` is the root exception that you should inherit for errors that are thrown within action functions. This syntax allows your frontend to pick up on the error parameters. APIExceptions are just Pydantic BaseModels with a few helpful defaults, and a metaclass that allows them to work natively with HTTPExceptions.
+The `APIException` is the root exception that you should inherit for errors that are thrown within action functions.
+This syntax allows your frontend to pick up on the error parameters.
+APIExceptions are just Pydantic BaseModels with a few helpful defaults, and a metaclass that allows them to work natively with HTTPExceptions.
 
 ::: mountaineer.exceptions.APIException

--- a/docs/api/build_plugins/base/page.mdx
+++ b/docs/api/build_plugins/base/page.mdx
@@ -1,5 +1,6 @@
 # Build Plugin Base
 
-Use the `ClientBuilderBase` to implement a new stage or custom handling during the frontend build lifecycle. Note that this API is still under development and might change between minor Mountaineer versions.
+Use the `ClientBuilderBase` to implement a new stage or custom handling during the frontend build lifecycle.
+Note that this API is still under development and might change between minor Mountaineer versions.
 
 ::: mountaineer.client_compiler.base.ClientBuilderBase

--- a/docs/api/cli/page.mdx
+++ b/docs/api/cli/page.mdx
@@ -1,6 +1,7 @@
 # CLI Plugins
 
-CLI Plugins provide default handling for the most common lifecycle events during Mountaineer development. Import these if convenient, otherwise you can follow our implementation approaches to implement your own.
+CLI Plugins provide default handling for the most common lifecycle events during Mountaineer development.
+Import these if convenient, otherwise you can follow our implementation approaches to implement your own.
 
 ## Webapp CLI
 
@@ -10,31 +11,29 @@ CLI Plugins provide default handling for the most common lifecycle events during
 
 ::: mountaineer.cli.handle_build
 
-Building your app will compile your TypeScript into the client-side bundle that will be downloaded
-by the browser. It also ahead-of-time generates the server code that will be run as part of [SSR](./ssr.md).
-You'll want to do it before deploying your application into production - but since a full build can take up
-to 10s, `handle_runserver` provides a better workflow for daily development.
+Building your app will compile your TypeScript into the client-side bundle that will be downloaded by the browser.
+It also ahead-of-time generates the server code that will be run as part of [SSR](./ssr.md).
+You'll want to do it before deploying your application into production - but since a full build can take up to 10s, `handle_runserver` provides a better workflow for daily development.
 
 ## Global Env
 
-Our development server (used in `runserver` and `watch`) uses firehot to isolate imports during
-reloads. This requires that third party packages don't spawn any threads
-during their import, otherwise you might see a warning like the following:
+Our development server (used in `runserver` and `watch`) uses firehot to isolate imports during reloads.
+This requires that third party packages don't spawn any threads during their import, otherwise you might see a warning like the following:
 
-```
+```text
 [2025-03-14T23:47:49Z ERROR firehot::layer] Import of 'gent.config' introduced 2 new threads:
 [2025-03-14T23:47:49Z ERROR firehot::layer]   - Total threads: 1 -> 3
 [2025-03-14T23:47:49Z ERROR firehot::layer]   - Python threads: 1 -> 1
 [2025-03-14T23:47:49Z ERROR firehot::layer]   - C/native threads: 0 -> 2
 ```
 
-If you see this error, we suggest diving into the module's implementation and seeing why it launches
-threads on import. This is an antipattern in library design. If you've confirmed the behavior is as-expected
-(which it is particularly in numerical computation libraries), you can selectively exclude the module from
-being imported into the main process. Instead it will delay until it's loaded in your application layer. This makes
-hotreloads a bit slower:
+If you see this error, we suggest diving into the module's implementation and seeing why it launches threads on import.
+This is an antipattern in library design.
+If you've confirmed the behavior is as-expected (which it is particularly in numerical computation libraries), you can selectively exclude the module from being imported into the main process.
+Instead it will delay until it's loaded in your application layer.
+This makes hotreloads a bit slower:
 
-```
+```text
 MOUNTAINEER_IGNORE_HOTRELOAD=gent.config,gent.main poetry run runserver
 ```
 

--- a/docs/api/controllers/page.mdx
+++ b/docs/api/controllers/page.mdx
@@ -1,6 +1,8 @@
 # Controllers
 
-Controllers are the heart of Mountaineer. They are the Python classes that define the logic for your views, layouts, and apps. They are responsible for rendering the view, handling side effects, and managing the state of your application.
+Controllers are the heart of Mountaineer.
+They are the Python classes that define the logic for your views, layouts, and apps.
+They are responsible for rendering the view, handling side effects, and managing the state of your application.
 
 ## View Controller
 
@@ -28,12 +30,11 @@ Controllers are the heart of Mountaineer. They are the Python classes that defin
 
 ## Metadata
 
-We provide support for all header tags that you'll find within an html `<head>`. These
-won't be rendered by your browser but are where you'll place style imports and page
-metadata for SEO.
+We provide support for all header tags that you'll find within an html `<head>`.
+These won't be rendered by your browser but are where you'll place style imports and page metadata for SEO.
 
-We have passthrough classes for all the common tags
-so they align to what's outputted in HTML. These are defined and referenced below as `ScriptAttribute`, `LinkAttribute`, `MetaAttribute`, etc.
+We have passthrough classes for all the common tags so they align to what's outputted in HTML.
+These are defined and referenced below as `ScriptAttribute`, `LinkAttribute`, `MetaAttribute`, etc.
 We also provide some convenient shortcuts for more complicated, common meta tags.
 
 ::: mountaineer.render.Metadata
@@ -60,9 +61,12 @@ We also provide some convenient shortcuts for more complicated, common meta tags
 
 ---
 
-# SSR
+## SSR
 
-Every page on Mountaineer is server-side rendered by default. Most SSR logic is handled in our embedded Rust layer. In Rust we spin up a V8 isolate, handle logging, catch and process exceptions, etc. This page only covers the client functions that are exposed to Python.
+Every page on Mountaineer is server-side rendered by default.
+Most SSR logic is handled in our embedded Rust layer.
+In Rust we spin up a V8 isolate, handle logging, catch and process exceptions, etc.
+This page only covers the client functions that are exposed to Python.
 
 ::: mountaineer.ssr.render_ssr
 

--- a/docs/api/core_dependencies/page.mdx
+++ b/docs/api/core_dependencies/page.mdx
@@ -1,7 +1,7 @@
 # Core Dependencies
 
-Dependency classes are a convention in the Mountaineer ecosystem. They provide common functions
-that you might want to use at runtime, either in your `render` or `sideeffect` functions.
+Dependency classes are a convention in the Mountaineer ecosystem.
+They provide common functions that you might want to use at runtime, either in your `render` or `sideeffect` functions.
 
 ::: mountaineer.dependencies.CoreDependencies
 

--- a/docs/api/development/page.mdx
+++ b/docs/api/development/page.mdx
@@ -1,40 +1,34 @@
 # Build Process
 
-Our "client builder" collection of classes manages generating the Typescript definitions from
-the defined Python controllers. While this component doesn't affect the actual value of the parsed
-values retrieved from the `fetched()` API at runtime, it's critical for development (IDE typehints
-and CI static typechecking). Working with type interfaces that are always in sync with the backend
-is one of the core benefits of using Mountaineer.
+Our "client builder" collection of classes manages generating the Typescript definitions from the defined Python controllers.
+While this component doesn't affect the actual value of the parsed values retrieved from the `fetched()` API at runtime, it's critical for development (IDE typehints and CI static typechecking).
+Working with type interfaces that are always in sync with the backend is one of the core benefits of using Mountaineer.
 
 Note that this documentation is mostly intended for core maintainers who are working on the
 Mountaineer codebase, versus on projects that use Mountaineer.
 
 ## Evolution
 
-In our 0.1-0.8 releases, the client builder operated on the OpenAPI schema that was generated from
-the API server. This ensured that definitions always matched the JS-like typing of the OpenAPI.
+In our 0.1-0.8 releases, the client builder operated on the OpenAPI schema that was generated from the API server.
+This ensured that definitions always matched the JS-like typing of the OpenAPI.
 There were some limitations to this approach:
 
-- Loss of inheritance tree: Each controller provided flat functions into the OpenAPI schema,
-  without any of their class inheritance structure. This made it impossible to define function
-  signatures in TS that relied on a common ancessor without specifying all of the downstream
-  client subclasses.
+- Loss of inheritance tree: Each controller provided flat functions into the OpenAPI schema, without any of their class inheritance structure.
+  This made it impossible to define function signatures in TS that relied on a common ancessor without specifying all of the downstream client subclasses.
 - Formatting of enum: Enums only define their values within OpenAPI, not their Python names.
-  We would build up a synthetic enum key/value pair based on the string value but in cases
-  where key/value in Python were meaningfully different (e.g. `Enum("foo", "bar")`), we would
-  lose that information.
+  We would build up a synthetic enum key/value pair based on the string value but in cases where key/value in Python were meaningfully different (e.g.
+  `Enum("foo", "bar")`), we would lose that information.
 
-In 0.9 we moved to a new approach that uses the Python controllers directly to generate the
-TypeScript definitions. This corrects all of the drawbacks of the OpenAPI approach in addition
-to cleaning up the code to more easily make extensions in the future.
+In 0.9 we moved to a new approach that uses the Python controllers directly to generate the TypeScript definitions.
+This corrects all of the drawbacks of the OpenAPI approach in addition to cleaning up the code to more easily make extensions in the future.
 
 Our new architecture is structured like so:
 
 **In-Memory Controllers**: Controllers are loaded into memory from their disk files so we have full
 access to their code signatures and runtime state.
 
-**Parser**: Extracts all metadata of the controllers/models necessary to generate TypeScript definitions. These
-  are stored in intermediate data classes.
+**Parser**: Extracts all metadata of the controllers/models necessary to generate TypeScript definitions.
+These are stored in intermediate data classes.
 
   - ControllerWrapper
   - FieldWrapper
@@ -42,8 +36,8 @@ access to their code signatures and runtime state.
   - ModelWrapper
   - EnumWrapper
 
-**InterfaceBuilder**: Takes the metadata and generates isolated TypeScript definitions. These are separated by output
-type (interface vs. enum for instance) so we can compartmentalize the string construction of frontend files.
+**InterfaceBuilder**: Takes the metadata and generates isolated TypeScript definitions.
+These are separated by output type (interface vs. enum for instance) so we can compartmentalize the string construction of frontend files.
 
   - ControllerInterface
   - ModelInterface
@@ -55,20 +49,20 @@ type (interface vs. enum for instance) so we can compartmentalize the string con
 
 ## App Isolation
 
-When you run our development server via `runserver`, we spawn your app in a new process. This
-process is isolated from the main runserver process by a message broker. This allows us to send messages
-to the app to reload code, restart the server, or shutdown the app.
+When you run our development server via `runserver`, we spawn your app in a new process.
+This process is isolated from the main runserver process by a message broker.
+This allows us to send messages to the app to reload code, restart the server, or shutdown the app.
 
-For small projects, performing a full process restart can be sufficient to update code files. But as projects
-grow larger, the bootup time for Python to read all your modules into memory can become meaningful. Mountaineer works
-around this limitation by implementing a hot-reloader. Our hot reloader waits for changes to files
-on disk and then reloads the changed modules in-memory without a full server restart. We do a best-effort
-approach to build up a DAG of dependencies between modules so we can reload them in the correct order.
+For small projects, performing a full process restart can be sufficient to update code files.
+But as projects grow larger, the bootup time for Python to read all your modules into memory can become meaningful.
+Mountaineer works around this limitation by implementing a hot-reloader.
+Our hot reloader waits for changes to files on disk and then reloads the changed modules in-memory without a full server restart.
+We do a best-effort approach to build up a DAG of dependencies between modules so we can reload them in the correct order.
 
-There are some cases, however, where we can't naively reload a module. One common case is in SQLAlchemy where Table
-definitions can only be added once to the global registry. If we were to reload a module that added a table to the
-registry, it raises a runtime exception. In these cases our dev session will fall back to rebuilding the app state
-instead of a targeted reload.
+There are some cases, however, where we can't naively reload a module.
+One common case is in SQLAlchemy where Table definitions can only be added once to the global registry.
+If we were to reload a module that added a table to the registry, it raises a runtime exception.
+In these cases our dev session will fall back to rebuilding the app state instead of a targeted reload.
 
 Regardless of the approach, the main process will wait for the new server to boot up and then send a notification
 to the frontend via our websocket server `WatcherWebservice`.

--- a/docs/api/logging/page.mdx
+++ b/docs/api/logging/page.mdx
@@ -1,17 +1,14 @@
 # Logging
 
-Mountaineer bundles a `mountaineer.logging` module for service-level logs. To adjust
-the verbosity of Mountaineer's logs, set the `MOUNTAINEER_LOG_LEVEL` environment
-variable.
+Mountaineer bundles a `mountaineer.logging` module for service-level logs.
+To adjust the verbosity of Mountaineer's logs, set the `MOUNTAINEER_LOG_LEVEL` environment variable.
 
 ```bash
 MOUNTAINEER_LOG_LEVEL=WARN mountaineer runserver
 ```
 
-We also provide some helper functions to use our same logging convention in your
-own code. We optimize for structured logging, where your logs are outputted as a
-stream of JSON-line formatted logs so they can be quickly parsed by bash pipes or
-by logging aggregation tools.
+We also provide some helper functions to use our same logging convention in your own code.
+We optimize for structured logging, where your logs are outputted as a stream of JSON-line formatted logs so they can be quickly parsed by bash pipes or by logging aggregation tools.
 
 ---
 

--- a/docs/guides/actions/page.mdx
+++ b/docs/guides/actions/page.mdx
@@ -1,22 +1,36 @@
 # Client Actions
 
-Conventionally, server mutations that affect a page state are a bit of a hassle. You need to keep track of modified attributes, issue an API call, then reload or merge them into the current page. All of this to mostly just update the state that the original page was initialized with in the first place.
+Conventionally, server mutations that affect a page state are a bit of a hassle.
+You need to keep track of modified attributes, issue an API call, then reload or merge them into the current page.
+All of this to mostly just update the state that the original page was initialized with in the first place.
 
-Actions are a way to simplify this process. They allow you to define server-side mutations that can be called from the client as if they're regular Javascript functions. Their request and response payloads are typehinted so you can statically verify their behavior.
+Actions are a way to simplify this process.
+They allow you to define server-side mutations that can be called from the client as if they're regular Javascript functions.
+Their request and response payloads are typehinted so you can statically verify their behavior.
 
 ## Action Types
 
-Anytime clients need to modify the server state, we denote these requests as "actions". Internally, they're just POST requests that are sent to the server. There's no black magic to this syntax. You can inspect them all in your browser's console as regular JSON.
+Anytime clients need to modify the server state, we denote these requests as "actions".
+Internally, they're just POST requests that are sent to the server.
+There's no black magic to this syntax.
+You can inspect them all in your browser's console as regular JSON.
 
 Your choice of action type depends on how you want to update _client_ data after your _server_ action has been executed.
 
-**@sideeffect:** Update the server data that initialized the client view. Sideeffects are also passthroughs, by definition, so they can pass back arbitrary data that is outside of the scope of the render() data payload. Use a sideeffect whenever the client modifies some data that lives on the server.
+**@sideeffect:** Update the server data that initialized the client view.
+Sideeffects are also passthroughs, by definition, so they can pass back arbitrary data that is outside of the scope of the render() data payload.
+Use a sideeffect whenever the client modifies some data that lives on the server.
 
-**@passthrough:** Expose an action to the client caller but don't update the server data once the action has been completed. Use a passthrough whenever you need to fetch additional data from the server, or the mutation on the server doesn't affect the local frontend state.
+**@passthrough:** Expose an action to the client caller but don't update the server data once the action has been completed.
+Use a passthrough whenever you need to fetch additional data from the server, or the mutation on the server doesn't affect the local frontend state.
 
 ## Side Effect
 
-Side-effects work as if you have reloaded the page. They update the server state and then push the updated state back to the client. They will call a fully fresh `render()` on the server so you can provide the latest data state to the client. However, unlike a true refresh on the client side, there's no actual browser refresh that is performed. This allows you to receive the updated data definition and keep the rest of your variables saved in local state.
+Side-effects work as if you have reloaded the page.
+They update the server state and then push the updated state back to the client.
+They will call a fully fresh `render()` on the server so you can provide the latest data state to the client.
+However, unlike a true refresh on the client side, there's no actual browser refresh that is performed.
+This allows you to receive the updated data definition and keep the rest of your variables saved in local state.
 
 `@sideeffect` can either be called with default behavior or customized via decorator arguments:
 
@@ -59,21 +73,30 @@ const response = await serverState.increment_count({
 
 You can also manually inspect the sideeffect payload by accessing `response.sideeffect`.
 
-If the action has a passthrough, it will be supplied in `response.passthrough`. Otherwise it will be undefined.
+If the action has a passthrough, it will be supplied in `response.passthrough`.
+Otherwise it will be undefined.
 
 ### Experimental Render Reloader
 
 !!! warning
 
-    This feature is experimental and only supports relatively simple render() function implementations. If you use it for a more complicated render() function and it doesn't work as expected, report a bug to improve the test coverage.
+```text
+This feature is experimental and only supports relatively simple render() function implementations. If you use it for a more complicated render() function and it doesn't work as expected, report a bug to improve the test coverage.
+```
 
-Render functions sometimes have heavy logic overhead: they need to fetch multiple objects from the database, do some roll-up computation, etc. If you're issuing a sideeffect that only affects a small portion of the initial data, this is wasted computation.
+Render functions sometimes have heavy logic overhead: they need to fetch multiple objects from the database, do some roll-up computation, etc.
+If you're issuing a sideeffect that only affects a small portion of the initial data, this is wasted computation.
 
-Passing a `reload` filter to `sideeffect` prevents this redundant data from being sent to the frontend. But this feature only saves bandwidth; it doesn't actually prevent the server from doing the computation in the first place. This is where the `experimental_render_reload` comes in.
+Passing a `reload` filter to `sideeffect` prevents this redundant data from being sent to the frontend.
+But this feature only saves bandwidth; it doesn't actually prevent the server from doing the computation in the first place.
+This is where the `experimental_render_reload` comes in.
 
-When this flag is set to `True`, Mountaineer will inspect the AST ([Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree)) of your render function. It creates a new synthetic render function that only does the computation required to calculate the `reload` parameters. If some intensive compute isn't required for your sideeffect, it will be ignored.
+When this flag is set to `True`, Mountaineer will inspect the AST ([Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree)) of your render function.
+It creates a new synthetic render function that only does the computation required to calculate the `reload` parameters.
+If some intensive compute isn't required for your sideeffect, it will be ignored.
 
-We compile this function into the Python runtime so it runs with the same performance as if you had implemented an alternative `render()` function yourself. Depending on your full render function complexity, this can lead to significant performance improvements.
+We compile this function into the Python runtime so it runs with the same performance as if you had implemented an alternative `render()` function yourself.
+Depending on your full render function complexity, this can lead to significant performance improvements.
 
 Let's consider the following render function:
 
@@ -97,7 +120,8 @@ def call_sideeffect(self, payload: dict) -> None:
     pass
 ```
 
-Benchmarked on a Macbook M1, calling this initial render will perform ~1.84s of compute. It results in:
+Benchmarked on a Macbook M1, calling this initial render will perform ~1.84s of compute.
+It results in:
 
 ```json
 {
@@ -106,7 +130,8 @@ Benchmarked on a Macbook M1, calling this initial render will perform ~1.84s of 
 }
 ```
 
-When `call_sideeffect` is called with `experimental_render_reload=True`, the compute only takes `0.010s`. It results in:
+When `call_sideeffect` is called with `experimental_render_reload=True`, the compute only takes `0.010s`.
+It results in:
 
 ```json
 {
@@ -116,7 +141,8 @@ When `call_sideeffect` is called with `experimental_render_reload=True`, the com
 
 ## Passthrough
 
-Passthrough is conceptually much simpler, since it doesn't perform any server->client data syncs once it's finished. Instead, it provides a simple decorator that optionally accepts a ResponseModel:
+Passthrough is conceptually much simpler, since it doesn't perform any server->client data syncs once it's finished.
+Instead, it provides a simple decorator that optionally accepts a ResponseModel:
 
 ```python
 # no parameters, no response model
@@ -143,7 +169,8 @@ console.log(response.passthrough);
 
 [Server-event](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) streams are a useful paradigm in webapp design, and increasing utilized to provide realtime Server->Client data for use in user notifications, CI feedback, and model inference.
 
-Mountaineer supports these natively on the server and client side. Simply decorate your response_model with a `typing.AsyncIterator` annotation and implement an async generator like you normally do:
+Mountaineer supports these natively on the server and client side.
+Simply decorate your response_model with a `typing.AsyncIterator` annotation and implement an async generator like you normally do:
 
 ```python
 from typing import AsyncIterator
@@ -163,9 +190,12 @@ class MyController(ControllerBase):
         yield MyMetadata(state=2)
 ```
 
-For the time being we only support server-events in `@passthrough` functions, not `@sideeffect`. It's ill-defined whether we should re-render() content every yield or when the iterator has finished. Yielding in passthrough makes it clear that you just want to stream the yielded value to the client.
+For the time being we only support server-events in `@passthrough` functions, not `@sideeffect`.
+It's ill-defined whether we should re-render() content every yield or when the iterator has finished.
+Yielding in passthrough makes it clear that you just want to stream the yielded value to the client.
 
-In your frontend, you can iterate over these responses with an async generator loop. Each response object will be parsed into your typed schema for you, so you can see typehints like you would for any regular Mountaineer action.
+In your frontend, you can iterate over these responses with an async generator loop.
+Each response object will be parsed into your typed schema for you, so you can see typehints like you would for any regular Mountaineer action.
 
 ```typescript
 import React, { useState, useEffect } from "react";
@@ -197,7 +227,9 @@ When defining your action functions themselves in your controller, we support ty
 - Pydantic models for JSON payloads
 - Dependency injection via `fastapi.Depends`
 
-We also support both sync and async functions. Sync functions will be spawned into a thread pool by default - which processes them in parallel but can tax system resources with GIL locking. Where possible, use async functions with libraries that support await constructs.
+We also support both sync and async functions.
+Sync functions will be spawned into a thread pool by default - which processes them in parallel but can tax system resources with GIL locking.
+Where possible, use async functions with libraries that support await constructs.
 
 A common sideeffect pattern might look like this:
 
@@ -226,4 +258,6 @@ class MyController(ControllerBase):
 
 !!! warning
 
-    Actions are publicly exposed to the Internet by default. It's up to you to secure them with authentication if they should only be accessible by a certain portion of your userbase.
+```text
+Actions are publicly exposed to the Internet by default. It's up to you to secure them with authentication if they should only be accessible by a certain portion of your userbase.
+```

--- a/docs/guides/deploy/page.mdx
+++ b/docs/guides/deploy/page.mdx
@@ -1,14 +1,17 @@
 # Deploy
 
-You can deploy your Mountaineer project using whatever container technology you'd like, on whatever hosting provider you'd like. Most hosts at this point mandate or highly encourage containerization of your dependencies with Docker - so we start there.
+You can deploy your Mountaineer project using whatever container technology you'd like, on whatever hosting provider you'd like.
+Most hosts at this point mandate or highly encourage containerization of your dependencies with Docker - so we start there.
 
-This page contains a reasonable default configuration to get you started. We make heavy use of multi-stage builds to cache dependencies and minimize the size of your final image that your webservers will have to pull down.
+This page contains a reasonable default configuration to get you started.
+We make heavy use of multi-stage builds to cache dependencies and minimize the size of your final image that your webservers will have to pull down.
 
 ## Docker
 
-First, add the following to your `.dockerignore` file. This will prevent Docker from trying to copy over heavy artifacts that aren't needed for the build.
+First, add the following to your `.dockerignore` file.
+This will prevent Docker from trying to copy over heavy artifacts that aren't needed for the build.
 
-```
+```text
 **/node_modules
 **/_server
 **/_ssr
@@ -18,7 +21,8 @@ First, add the following to your `.dockerignore` file. This will prevent Docker 
 
 ### Image 1: Frontend Dependencies
 
-Our first stage uses `npm` to fetch your frontend dependencies. This is an isolated context since it's the only place we need node / npm in the build pipeline.
+Our first stage uses `npm` to fetch your frontend dependencies.
+This is an isolated context since it's the only place we need node / npm in the build pipeline.
 
 ```docker
 FROM node:20-slim as node-dependencies
@@ -32,7 +36,10 @@ RUN npm install
 
 ### Image 2: Python Dependencies Base
 
-Our build pipeline requires Poetry and a basic Python configuration in multiple stages. This initial stage sets up the Poetry CLI and a Python 3.11 environment. By default we make use of Docker's `buildx` to compile for linux/amd64 (Intel) since this is what most servers run on. It also lets us leverage our prebuild Mountaineer wheels.
+Our build pipeline requires Poetry and a basic Python configuration in multiple stages.
+This initial stage sets up the Poetry CLI and a Python 3.11 environment.
+By default we make use of Docker's `buildx` to compile for linux/amd64 (Intel) since this is what most servers run on.
+It also lets us leverage our prebuild Mountaineer wheels.
 
 ```docker
 FROM --platform=linux/amd64 python:3.11-slim as poetry-base

--- a/docs/guides/errors/page.mdx
+++ b/docs/guides/errors/page.mdx
@@ -1,14 +1,20 @@
 # Error Handling
 
-Errors are a fundamental part of computer science, but nowhere is that more evident than when building websites. There are so many factors you don't have control over: client latency, malformed payloads, spiky server load, resource contention for the same user. The list goes on. Any one can bring a user experience to its knees.
+Errors are a fundamental part of computer science, but nowhere is that more evident than when building websites.
+There are so many factors you don't have control over: client latency, malformed payloads, spiky server load, resource contention for the same user.
+The list goes on.
+Any one can bring a user experience to its knees.
 
-All that to say - it's not a question of _if_ you'll see errors but _when_. Mountaineer provides some handy utilities that make it a bit easier to handle the errors you may encounter in production.
+All that to say - it's not a question of _if_ you'll see errors but _when_.
+Mountaineer provides some handy utilities that make it a bit easier to handle the errors you may encounter in production.
 
 ## Client->Server exceptions
 
-When client actions call server actions (either sideeffects or passthroughs), their browser needs to make an outgoing fetch request to your server. Your server can throw an error in response to this payload for any reason: validation failures, unexpected state, or just because some internal logic failed.
+When client actions call server actions (either sideeffects or passthroughs), their browser needs to make an outgoing fetch request to your server.
+Your server can throw an error in response to this payload for any reason: validation failures, unexpected state, or just because some internal logic failed.
 
-When your server returns an error, your async action will raise the relevant error. Let's say you have the following component that issues an invalid call to a server action:
+When your server returns an error, your async action will raise the relevant error.
+Let's say you have the following component that issues an invalid call to a server action:
 
 ```typescript
 <button
@@ -25,7 +31,10 @@ When your server returns an error, your async action will raise the relevant err
 </button>
 ```
 
-When this button is clicked, it will send an `increment_count` action to the server. The server will validate the incoming payload with Pydantic, which will throw a [ValidationError](https://docs.pydantic.dev/latest/errors/validation_errors/) since it expects `count` to be an integer, not a string. The server will then respond with a 422 validation error, which will be passed back to the client and raised in the async function. You can catch this error with a try/catch block:
+When this button is clicked, it will send an `increment_count` action to the server.
+The server will validate the incoming payload with Pydantic, which will throw a [ValidationError](https://docs.pydantic.dev/latest/errors/validation_errors/) since it expects `count` to be an integer, not a string.
+The server will then respond with a 422 validation error, which will be passed back to the client and raised in the async function.
+You can catch this error with a try/catch block:
 
 ```typescript
 import { HTTPValidationErrorException } from "./_server/actions";
@@ -59,27 +68,31 @@ import { HTTPValidationErrorException } from "./_server/actions";
 </button>
 ```
 
-Mountaineer will convert the error into a custom error class and expose it in `_server/actions` for you to import. This class helps you switch logic depending on the type of error that was raised. Using a class here also has the benefit of typeguarding your error handling, so you'll see IDE recommendations specific to that ValidationError.
+Mountaineer will convert the error into a custom error class and expose it in `_server/actions` for you to import.
+This class helps you switch logic depending on the type of error that was raised.
+Using a class here also has the benefit of typeguarding your error handling, so you'll see IDE recommendations specific to that ValidationError.
 
-You can find the error payload itself within `error.body`, which will be typehinted with all the metadata (if any) that the server is expected to return as part of this error code. In the above example, that looks like this:
+You can find the error payload itself within `error.body`, which will be typehinted with all the metadata (if any) that the server is expected to return as part of this error code.
+In the above example, that looks like this:
 
-```
+```text
 Validation Error (2) ['body', 'count'] Input should be a valid integer, unable to parse string as an integer
 ```
 
-Internally, we generate `HTTPValidationErrorException` as a subclass of FetchErrorBase. This provided the common error handling, while typehinting it for your specific API errors.
+Internally, we generate `HTTPValidationErrorException` as a subclass of FetchErrorBase.
+This provided the common error handling, while typehinting it for your specific API errors.
 
 ```typescript title="_server/actions.ts"
 class HTTPValidationErrorException extends FetchErrorBase<HTTPValidationError> {}
 ```
 
-<Note>
-    For more information on error typehinting and custom handling, see the FastAPI [documentation](https://fastapi.tiangolo.com/tutorial/handling-errors/).
-</Note>
+<Note> For more information on error typehinting and custom handling, see the FastAPI [documentation](https://fastapi.tiangolo.com/tutorial/handling-errors/). .
+. . </Note>
 
 ## Custom Errors
 
-A 422 ValidationError is a special error that is included in every action, because your function signature is verified every time a client sends a new payload to your server. To implement a custom error that is specific to your application, you can subclass `APIException`:
+A 422 ValidationError is a special error that is included in every action, because your function signature is verified every time a client sends a new payload to your server.
+To implement a custom error that is specific to your application, you can subclass `APIException`:
 
 ```python
 from mountaineer.exceptions import APIException
@@ -96,27 +109,36 @@ class LoginController(ControllerBase):
         raise LoginInvalid(invalid_reason="Login not implemented")
 ```
 
-Provide all the exceptions that your function may throw to `@passthrough(exception_models=[])`. The `@sideeffect` decorator accepts the same argument.
+Provide all the exceptions that your function may throw to `@passthrough(exception_models=[])`.
+The `@sideeffect` decorator accepts the same argument.
 
-When specified like this, Mountaineer turns your exception into a client-side exception just like `HTTPValidationErrorException`. You can now use it in the same way.
+When specified like this, Mountaineer turns your exception into a client-side exception just like `HTTPValidationErrorException`.
+You can now use it in the same way.
 
 ## SSR timeouts
 
-To render each page on the server side, we have to execute your view's Javascript in a V8 engine. This is the same Javascript interpreter that powers Chrome. As such, you have the full freedom to write any Javascript in your view that will help you render your page - loops, calculations, package calls, etc.
+To render each page on the server side, we have to execute your view's Javascript in a V8 engine.
+This is the same Javascript interpreter that powers Chrome.
+As such, you have the full freedom to write any Javascript in your view that will help you render your page - loops, calculations, package calls, etc.
 
 As is the case with Turing-complete languages, with great power comes great responsibility.
 
-These SSR requests can potentially take a long time. At the extreme, they could even clog up your server by infinite looping and never returning a value. We have a series of safeguards in place to help ensure SSR renders return quickly and keep your server able to chug through additional requests.
+These SSR requests can potentially take a long time.
+At the extreme, they could even clog up your server by infinite looping and never returning a value.
+We have a series of safeguards in place to help ensure SSR renders return quickly and keep your server able to chug through additional requests.
 
 - Debug logging of the duration of each SSR page render, for use in development.
 - Warning logs if rendering takes longer than some interval so you can keep an eye on endpoints that might need some optimization.
-- Hard timeouts for rendering. If something goes sideways and your server rendering takes longer a maximum threshold, we'll terminate the server-side Javascript executor for you and return an error to the client.
+- Hard timeouts for rendering.
+  If something goes sideways and your server rendering takes longer a maximum threshold, we'll terminate the server-side Javascript executor for you and return an error to the client.
 
 ## SSR exceptions
 
-Alongside timeouts, it's possible your view's Javascript actually gets into an unrecoverable state and throws an exception during rendering. To help you debug this on the server side, we'll raise this error as a `mountaineer.ssr.V8RuntimeError` and log the stack trace that comes back from the V8 engine.
+Alongside timeouts, it's possible your view's Javascript actually gets into an unrecoverable state and throws an exception during rendering.
+To help you debug this on the server side, we'll raise this error as a `mountaineer.ssr.V8RuntimeError` and log the stack trace that comes back from the V8 engine.
 
-The paths reported in the stack trace are found from the sourcemap that's created alongside the compiled SSR files. These should point to the files in your view directory that have produced that exception.
+The paths reported in the stack trace are found from the sourcemap that's created alongside the compiled SSR files.
+These should point to the files in your view directory that have produced that exception.
 
 ```bash
 {"level": "ERROR", "name": "mountaineer.logging", "message": "Exception encountered in ComplexController rendering"}

--- a/docs/guides/links/page.mdx
+++ b/docs/guides/links/page.mdx
@@ -1,8 +1,12 @@
 # Links
 
-In a typical webapp, you'll have a lot of links. Most will be internal to your site: detail pages, settings, profiles, etc. Traditionally, developers format these links manually and hope they don't break over time as routes update.
+In a typical webapp, you'll have a lot of links.
+Most will be internal to your site: detail pages, settings, profiles, etc.
+Traditionally, developers format these links manually and hope they don't break over time as routes update.
 
-In Mountaineer, generating links is baked into the client side routes. For every controller you define, we'll generate a link interface that defines the parameters that controller accepts. This interface will update as your route declarations do, so you're guaranteed to always generate the latest links to successfully resolve that controller.
+In Mountaineer, generating links is baked into the client side routes.
+For every controller you define, we'll generate a link interface that defines the parameters that controller accepts.
+This interface will update as your route declarations do, so you're guaranteed to always generate the latest links to successfully resolve that controller.
 
 Controllers set the parameters that they need to render their views by configuring the `render()` function with the required parameters:
 
@@ -16,9 +20,12 @@ class DetailController:
 
 Alongside generating the appropriate API and router files, Mountaineer will detect this render signature and produce a link generator.
 
-This particular generator will require a `detail_id` and support an optional `checking_out` boolean. The `detail_id` is required because it's a part of the controller url. `checking_out` on the other hand is optional, since it has a default keyword argument in the case that another value isn't provided.
+This particular generator will require a `detail_id` and support an optional `checking_out` boolean.
+The `detail_id` is required because it's a part of the controller url.
+`checking_out` on the other hand is optional, since it has a default keyword argument in the case that another value isn't provided.
 
-On the client side, you can now create these dynamic links anywhere within your application. Mount the server state of the current view and use the included `linkGenerator`.
+On the client side, you can now create these dynamic links anywhere within your application.
+Mount the server state of the current view and use the included `linkGenerator`.
 
 ```typescript
 const MyHomeRoute = () => {

--- a/docs/guides/metadata/page.mdx
+++ b/docs/guides/metadata/page.mdx
@@ -1,12 +1,10 @@
 # Page Metadata
 
-Pages will have metadata associated with them: page title, description,
-tags, stylesheets, etc. Mountaineer specifies this metadata in the Python
-layer, during the initial render.
+Pages will have metadata associated with them: page title, description, tags, stylesheets, etc.
+Mountaineer specifies this metadata in the Python layer, during the initial render.
 
-Each `RenderBase` schema implements a `metadata` attribute. This metadata
-lets you customize the different fields that are injected in your
-html `<head>` tag:
+Each `RenderBase` schema implements a `metadata` attribute.
+This metadata lets you customize the different fields that are injected in your html `<head>` tag:
 
 ```python
 class Metadata(BaseModel):
@@ -17,12 +15,10 @@ class Metadata(BaseModel):
 
 ## Title
 
-Setting a page title is pretty straightforward. You just return a
-Metadata instance within your `render()` function. Because the metadata
-logic is located in-scope of your other business logic, you can access
-the full suit of calculated values. This is helpful to conditionally
-generate a dynamic title - like injecting a user's account name, number
-of new messages, etc.
+Setting a page title is pretty straightforward.
+You just return a Metadata instance within your `render()` function.
+Because the metadata logic is located in-scope of your other business logic, you can access the full suit of calculated values.
+This is helpful to conditionally generate a dynamic title - like injecting a user's account name, number of new messages, etc.
 
 ```python
 class MyRender(RenderBase):
@@ -38,11 +34,8 @@ def render() -> MyRender:
 
 ## Meta and Links
 
-We provide a pretty vanilla syntax within `Metadata` so you can specify
-any `<meta>` and `<link>` elements you'd like. We do this with the
-recognition that only some meta tag values have been standardized, and
-others are left to the browser implementations or web crawlers to parse
-them appropriately.
+We provide a pretty vanilla syntax within `Metadata` so you can specify any `<meta>` and `<link>` elements you'd like.
+We do this with the recognition that only some meta tag values have been standardized, and others are left to the browser implementations or web crawlers to parse them appropriately.
 
 You'll typically instantiate a `<meta>` tag like this:
 
@@ -61,10 +54,8 @@ def render() -> MyRender:
     )
 ```
 
-We have a limited number of helper `<meta>` constructors, particularly in
-cases where there are standard definitions of complex meta values. For
-more details on the supported Metadata and rendering options, check out
-the [API Docs](/mountaineer/api/render).
+We have a limited number of helper `<meta>` constructors, particularly in cases where there are standard definitions of complex meta values.
+For more details on the supported Metadata and rendering options, check out the [API Docs](/mountaineer/api/render).
 
 ## Global Metadata
 

--- a/docs/guides/postcss/page.mdx
+++ b/docs/guides/postcss/page.mdx
@@ -2,23 +2,20 @@
 
 ## PostCSS
 
-[PostCSS](https://postcss.org/) is a compiler for CSS. It enables buildtime transformation
-of CSS files to convert SCSS, LESS, or other CSS-like languages into
-standard CSS. It also has utilities for polyfills and browser-specific
-prefixes. I think of it like a swiss-army knife for CSS: it helps ensure
-that your styling intentions are actually rendered uniformily across
-browsers.
+[PostCSS](https://postcss.org/) is a compiler for CSS.
+It enables buildtime transformation of CSS files to convert SCSS, LESS, or other CSS-like languages into standard CSS.
+It also has utilities for polyfills and browser-specific prefixes.
+I think of it like a swiss-army knife for CSS: it helps ensure that your styling intentions are actually rendered uniformily across browsers.
 
-PostCSS support is handled as a buildtime plugin with Mountaineer. It's
-disabled by default. To enable, make sure you have `postcss-cli` installed
-within your `views` project:
+PostCSS support is handled as a buildtime plugin with Mountaineer.
+It's disabled by default.
+To enable, make sure you have `postcss-cli` installed within your `views` project:
 
 ```bash
 npm install postcss-cli
 ```
 
-After this you can leverage the `PostCSSBundler` within your custom
-build pipeline:
+After this you can leverage the `PostCSSBundler` within your custom build pipeline:
 
 ```python
 from mountaineer.client_compiler.postcss import PostCSSBundler
@@ -30,32 +27,28 @@ mountaineer = Mountaineer(
 )
 ```
 
-Adding the PostCSSBundler will find all the `.css` that you have
-specified within your `views` directory and pass them through
-PostCSS. Let's say you have the following CSS files:
+Adding the PostCSSBundler will find all the `.css` that you have specified within your `views` directory and pass them through PostCSS.
+Let's say you have the following CSS files:
 
-```
+```text
 /views/app/home/style.css
 /views/app/detail/style.css
 ```
 
 The compiler will pass each through PostCSS and deposit these artifacts into:
 
-```
+```text
 /views/_static/home_style.css
 /views/_static/detail_style.css
 ```
 
-You can then import this CSS file in whatever `<meta>` tag is relevant
-to your project. See the [metadata documentation](/mountaineer/guides/metadata) for
-more details on how to do this.
+You can then import this CSS file in whatever `<meta>` tag is relevant to your project.
+See the [metadata documentation](/mountaineer/guides/metadata) for more details on how to do this.
 
 ## Tailwind
 
-Tailwind uses PostCSS to handle the tree shaking and project analysis
-that allows it to output the minimal amount of CSS tags to correctly render
-your project. If you set up the PostCSS extension like described above,
-you should be able to follow the typical Tailwind [setup](https://tailwindcss.com/docs/installation) steps.
+Tailwind uses PostCSS to handle the tree shaking and project analysis that allows it to output the minimal amount of CSS tags to correctly render your project.
+If you set up the PostCSS extension like described above, you should be able to follow the typical Tailwind [setup](https://tailwindcss.com/docs/installation) steps.
 
 ```typescript
 // views/app/tailwind.config.ts

--- a/docs/guides/structure/page.mdx
+++ b/docs/guides/structure/page.mdx
@@ -1,10 +1,11 @@
 # Conventions
 
-Mountaineer projects all follow a similar structure. Below is the recommended project layout.
+Mountaineer projects all follow a similar structure.
+Below is the recommended project layout.
 
 For a project called `my_webapp`, you should have something like the following:
 
-```
+```text
 my_webapp/
 ├── README.md
 ├── docker compose.yml
@@ -32,22 +33,29 @@ my_webapp/
 └── pyproject.toml
 ```
 
-Every service file is nested under the `my_webapp` root package. This is just a regular python project - you add new code files wherever you like and import them as you're used to.
+Every service file is nested under the `my_webapp` root package.
+This is just a regular python project - you add new code files wherever you like and import them as you're used to.
 
-### Mandatory Conventions
+## Mandatory Conventions
 
-`views` - this disk based directory includes a nested npm project. Within it you write all your frontend logics and components, which are regular typescript/tsx files.
+`views` - this disk based directory includes a nested npm project.
+Within it you write all your frontend logics and components, which are regular typescript/tsx files.
 
-Nested routes are in nested folders. This folder acts as your React project and is where you can define requirements and build parameters in `package.json` and `tsconfig.json`.
+Nested routes are in nested folders.
+This folder acts as your React project and is where you can define requirements and build parameters in `package.json` and `tsconfig.json`.
 
-Mountaineer supports advanced layout organization patterns, including the ability to isolate layouts to specific sections of your application using the `(root)` folder pattern. For more details, see the [Layout Organization](../views/layout-organization) guide.
+Mountaineer supports advanced layout organization patterns, including the ability to isolate layouts to specific sections of your application using the `(root)` folder pattern.
+For more details, see the [Layout Organization](../views/layout-organization) guide.
 
 ### Suggested Conventions
 
-`controllers` - A controller is the python logic that backs your frontend view. You can define controllers however you like: a flat folder, nesting folders, or via no folders at all mixed in with other code. For simplicity we recommend starting with a single flat controllers folder and refactoring into sub-folders as distinct ownership areas of your code emerge.
+`controllers` - A controller is the python logic that backs your frontend view.
+You can define controllers however you like: a flat folder, nesting folders, or via no folders at all mixed in with other code.
+For simplicity we recommend starting with a single flat controllers folder and refactoring into sub-folders as distinct ownership areas of your code emerge.
 
 `app.py` - Instantiate your controllers and add them to a `Mountaineer` instance to register them for client access.
 
-`config.py` - Specify the parameters that your application needs to run, to easily customize them: database host settings, secret keys, etc. Configurations can easily read from env variables and are globally accessible throughout your webapp.
+`config.py` - Specify the parameters that your application needs to run, to easily customize them: database host settings, secret keys, etc.
+Configurations can easily read from env variables and are globally accessible throughout your webapp.
 
 `main.py` - Create a FastAPI host app and mount your `Mountaineer` instance for ASGI servers like [uvicorn](https://www.uvicorn.org/).

--- a/docs/guides/tests/page.mdx
+++ b/docs/guides/tests/page.mdx
@@ -1,6 +1,8 @@
 # Tests
 
-By convention, Mountaineer applications use **pytest** and **pytest-asyncio** for comprehensive testing. The framework provides patterns for testing controllers, sideeffects, database operations, and frontend integrations with proper isolation and setup. You can use whatever testing framework you want if you're willing to go off road.
+By convention, Mountaineer applications use **pytest** and **pytest-asyncio** for comprehensive testing.
+The framework provides patterns for testing controllers, sideeffects, database operations, and frontend integrations with proper isolation and setup.
+You can use whatever testing framework you want if you're willing to go off road.
 
 Mountaineer applications should set up a complete testing environment with the necessary dependencies and configuration.
 
@@ -10,7 +12,7 @@ Mountaineer applications should set up a complete testing environment with the n
 
 Every new Mountaineer project includes a `__tests__/` directory with a pre-configured testing environment:
 
-```
+```text
 my_webapp/
 ├── __tests__/
 │   ├── __init__.py
@@ -26,7 +28,8 @@ my_webapp/
 
 ### Base Configuration (`conftest.py`)
 
-The template provides a robust test configuration that handles test setup and dependency injection. The generated `conftest.py` includes:
+The template provides a robust test configuration that handles test setup and dependency injection.
+The generated `conftest.py` includes:
 
 - **Automatic config setup** with test-time configuration
 - **Test fixtures** for common testing patterns
@@ -49,13 +52,16 @@ PACKAGE=my_webapp
 
 ### Testing Controller Render Functions
 
-The `render()` function is the heart of every controller - it defines what data your frontend receives. Testing render functions ensures that your controllers produce the correct data structure and handle various input scenarios properly.
+The `render()` function is the heart of every controller - it defines what data your frontend receives.
+Testing render functions ensures that your controllers produce the correct data structure and handle various input scenarios properly.
 
-**What we're testing**: The render function should return the expected data payload based on the current application state and request parameters. This is essentially testing your "read" operations.
+**What we're testing**: The render function should return the expected data payload based on the current application state and request parameters.
+This is essentially testing your "read" operations.
 
 _Testing Render with Data_
 
-The most common scenario is testing that when a user visits a page, they see the correct data. This test validates your application's "happy path" - when everything is working correctly and you have data to display.
+The most common scenario is testing that when a user visits a page, they see the correct data.
+This test validates your application's "happy path" - when everything is working correctly and you have data to display.
 
 We set up some test data, create a mock request (simulating a user visiting the page), call the render method, and verify both the response structure and the actual content.
 
@@ -99,7 +105,8 @@ async def test_home_render_with_todos():
 
 _Testing Render with Empty State_
 
-Your application should gracefully handle empty states, which is common when users first visit your app or when they've cleared all their data. This test ensures that your render function doesn't break when there's no data to display.
+Your application should gracefully handle empty states, which is common when users first visit your app or when they've cleared all their data.
+This test ensures that your render function doesn't break when there's no data to display.
 
 ```python
 @pytest.mark.asyncio
@@ -125,13 +132,16 @@ async def test_home_render_empty_state():
 
 ### Testing Action Functions (Sideeffects & Passthroughs)
 
-Action functions handle the "write" operations in your application - creating, updating, or deleting data. These tests ensure that user interactions properly modify your application state.
+Action functions handle the "write" operations in your application - creating, updating, or deleting data.
+These tests ensure that user interactions properly modify your application state.
 
-**What we're testing**: Action functions should correctly process user input, update application state, and trigger appropriate render refreshes. Both `@sideeffect` and `@passthrough` decorated functions follow similar testing patterns.
+**What we're testing**: Action functions should correctly process user input, update application state, and trigger appropriate render refreshes.
+Both `@sideeffect` and `@passthrough` decorated functions follow similar testing patterns.
 
 _Testing Data Creation_
 
-This test validates the most common user interaction - adding new data to your application. When users submit a form or click a button to create something new, you want to ensure that data is correctly saved.
+This test validates the most common user interaction - adding new data to your application.
+When users submit a form or click a button to create something new, you want to ensure that data is correctly saved.
 
 Since this uses a `@sideeffect` decorator, it will also trigger a render refresh on the frontend, keeping the UI in sync with the data.
 
@@ -168,7 +178,8 @@ async def test_add_todo_action():
 
 _Testing Data Updates_
 
-This test covers modification operations - when users interact with existing data to change its state. A common example is checking off a todo item to mark it complete.
+This test covers modification operations - when users interact with existing data to change its state.
+A common example is checking off a todo item to mark it complete.
 
 The test ensures that only the intended fields are modified while leaving other data unchanged.
 
@@ -203,7 +214,8 @@ async def test_toggle_todo_action():
 
 _Testing Error Handling_
 
-Your action functions should properly handle invalid input and provide appropriate feedback to users. This test ensures that when users submit malformed or incomplete data, your application gracefully rejects it without corrupting state.
+Your action functions should properly handle invalid input and provide appropriate feedback to users.
+This test ensures that when users submit malformed or incomplete data, your application gracefully rejects it without corrupting state.
 
 ```python
 @pytest.mark.asyncio
@@ -244,7 +256,8 @@ pytest -k "render"
 
 ### Additional Testing
 
-If your application uses a database or external services, make sure those are properly configured for testing. You may want to:
+If your application uses a database or external services, make sure those are properly configured for testing.
+You may want to:
 
 - Use separate test databases or in-memory databases
 - Mock external API calls

--- a/docs/guides/views/layout-organization.mdx
+++ b/docs/guides/views/layout-organization.mdx
@@ -1,12 +1,13 @@
 # Layout Organization
 
-Mountaineer supports flexible layout organization patterns inspired by Next.js. This guide explains how to structure your layouts for different scenarios.
+Mountaineer supports flexible layout organization patterns inspired by Next.js.
+This guide explains how to structure your layouts for different scenarios.
 
 ## Default Layout Structure
 
 By default, Mountaineer uses a cascading layout system where layouts apply to all pages in their directory and subdirectories:
 
-```
+```text
 views/
 └── app/
     ├── layout.tsx         # Root layout (applies to all pages)
@@ -24,9 +25,10 @@ In this structure, when rendering `dashboard/home/page.tsx`, the page will be wr
 
 ## Optional Layout Structure with (root) Folder
 
-For more granular control over which layouts apply to which pages, you can use the optional (root) folder pattern. This allows you to isolate layouts to specific sections of your application:
+For more granular control over which layouts apply to which pages, you can use the optional (root) folder pattern.
+This allows you to isolate layouts to specific sections of your application:
 
-```
+```text
 views/
 └── app/
     ├── (root)/            # Root group
@@ -38,10 +40,12 @@ views/
 ```
 
 In this structure:
+
 - The layout in `(root)/layout.tsx` only applies to pages within the `(root)` directory
 - Pages outside the `(root)` directory (like `dashboard/page.tsx`) don't inherit the root layout
 
 This pattern is useful when:
+
 - You want different sections of your app to have completely different layouts
 - You need to isolate layout changes to prevent them from affecting other parts of your application
 - You're building a multi-tenant application where each tenant needs its own layout
@@ -50,7 +54,7 @@ This pattern is useful when:
 
 You can also nest these layout groups for even more control:
 
-```
+```text
 views/
 └── app/
     ├── (root)/
@@ -67,6 +71,7 @@ views/
 
 ## Implementation Details
 
-When Mountaineer encounters a folder name wrapped in parentheses like `(root)`, it treats it as a layout group. The parentheses in the folder name are just a convention to indicate that this folder is used for layout organization and doesn't affect the actual URL routing.
+When Mountaineer encounters a folder name wrapped in parentheses like `(root)`, it treats it as a layout group.
+The parentheses in the folder name are just a convention to indicate that this folder is used for layout organization and doesn't affect the actual URL routing.
 
 This approach gives you the flexibility to organize your layouts in a way that matches your application's structure while maintaining clean separation between different sections.

--- a/mountaineer/__tests__/fixtures/ci_webapp/README.md
+++ b/mountaineer/__tests__/fixtures/ci_webapp/README.md
@@ -1,10 +1,12 @@
 # ci-webapp
 
-An example webapp, built with mountaineer. This is intended for use by CI only, to test various edge cases that are more easily served by a fully functioning webapp.
+An example webapp, built with mountaineer.
+This is intended for CI use only, to test edge cases more easily served by a fully functioning webapp.
 
 ## Getting Started
 
-We link to the local version of mountaineer in `pyproject.toml`. On the first install it should fetch dependencies with poetry and then build the rust components with maturin.
+We link to the local version of mountaineer in `pyproject.toml`.
+On the first install it should fetch dependencies with poetry and then build the rust components with maturin.
 
 ```bash
 poetry install
@@ -13,6 +15,8 @@ poetry install
 poetry run runserver
 ```
 
-If you're doing concurrent development in the main mountaineer codebase, you will have to manually restart the `runserver` command. Python changes in the main mountaineer package will be picked up - but you'll have to rebuild the rust artifacts with maturin. See the main README for instructions on how to do this.
+If doing concurrent development in the main codebase, you will have to manually restart the `runserver` command.
+Python changes in the main package will be picked up - but you'll need to rebuild rust artifacts with maturin.
+See the main README for instructions on how to do this.
 
 Changes in the my_website codebase should be automatically picked up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,13 @@ select = ["E4", "E7", "E9", "F", "I001", "T201"]
 [tool.ruff.lint.isort]
 combine-as-imports = true
 
+[tool.rumdl.MD013]
+line_length = 120
+reflow = true
+reflow-mode = "sentence-per-line"
+code-blocks = false
+tables = false
+
 [tool.pytest.ini_options]
 markers = ["integration_tests: run longer-running integration tests"]
 # Default pytest runs shouldn't execute the integration tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,4 +95,5 @@ dev = [
     "types-tqdm>=4.67.0.20250301",
     "maturin>=1.0,<2.0",
     "pre-commit>=4.5.1",
+    "rumdl>=0.1.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -369,6 +369,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "python-multipart" },
     { name = "ruff" },
+    { name = "rumdl" },
     { name = "toml" },
     { name = "tqdm" },
     { name = "types-setuptools" },
@@ -403,6 +404,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "ruff", specifier = ">=0.10.0" },
+    { name = "rumdl", specifier = ">=0.1.0" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "types-setuptools", specifier = ">=76.0.0.20250313" },
@@ -854,6 +856,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/aa/9f89c719c467dfaf8ad799b9bae0df494513fb21d31a6059cb5870e57e74/ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167", size = 10502442, upload-time = "2026-01-22T22:30:38.93Z" },
     { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486, upload-time = "2026-01-22T22:30:10.852Z" },
     { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448, upload-time = "2026-01-22T22:30:15.417Z" },
+]
+
+[[package]]
+name = "rumdl"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/02/6641457f33adafdc53e5e9f876341d345a35b296291998c819f21907dac4/rumdl-0.1.0.tar.gz", hash = "sha256:5273c18133eedc6899b03203e2195d8e54fc4eec826c241f306431860918cf34", size = 1701155, upload-time = "2026-01-23T20:25:28.351Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/197b23d69375717bd867bcf5b99478895cfc332861b980ce084534832e39/rumdl-0.1.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:de58598b8c6e9cb260d988c47c8f04e52de610cb22bdc3ea61bf0eee62112839", size = 3169806, upload-time = "2026-01-23T20:25:21.712Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/4c/baad3b9f0663fa40726e139eb757bf6b6a25a1091e6795cc53f0f1d410b5/rumdl-0.1.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7595a19e1f202521b1cb06496df5b6739a4b5f343af5ab614ca006453c3f5737", size = 3042746, upload-time = "2026-01-23T20:25:17.403Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/ad2af8340d077e9ad3abfd8fa2fef80872db9324d8f2b2fc39d67b59d8ce/rumdl-0.1.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:344cd51f8ab8f0aea54e06057dc9a4dcdbc2cf406da5de745cea4335254f0a6d", size = 3409450, upload-time = "2026-01-23T20:25:19.264Z" },
+    { url = "https://files.pythonhosted.org/packages/31/14/a4c7f9b545918b41a9ff2704e641bc5a563d3ec41843e1d041c2b4cced04/rumdl-0.1.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:34fc849f0f0e10e12847f8a21e2f587121546097e694c3ee63c27f52cba55e8e", size = 3461037, upload-time = "2026-01-23T20:25:25.171Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/99/b5d47585814bf12ccf53ff9ec9643876890dcc0d6304cb3b22e62de83eb7/rumdl-0.1.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2a0c3b80b585da4d511245276624b4fc78e6c61f64a246eee2dfca2a38531f34", size = 3397945, upload-time = "2026-01-23T20:25:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5c/e032fe302a27a5ef29ac8cb3189a32c1fd946834a35f2699db8029cf93c5/rumdl-0.1.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:566596df1bea8da8bf552c0d3eb81c3c10fe12681a8282ec4a9e1970a2dbe0cc", size = 3444174, upload-time = "2026-01-23T20:25:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/69/bd4977d4e138d4715b7aa93ad6d6d216874298352fb6e7dfa504bdaab252/rumdl-0.1.0-py3-none-win_amd64.whl", hash = "sha256:ade6002a935ef03fa26ae31d1174c4b033019bb37add18487ee476486b0fc83d", size = 3253871, upload-time = "2026-01-23T20:25:23.227Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Summary:
- add rumdl pre-commit hooks and configuration for sentence-per-line formatting
- reflow markdown and mdx docs to meet linting rules across guides, API docs, and design docs
- standardize documentation formatting in README and supporting examples

Testing:
- uv run pytest
- uv run pre-commit run --all

Design:
- N/A (formatting-only updates)